### PR TITLE
fix: ensure the pages are an array not an object

### DIFF
--- a/html/modules/custom/ocha_ai_chat/src/Services/OchaAiChat.php
+++ b/html/modules/custom/ocha_ai_chat/src/Services/OchaAiChat.php
@@ -534,6 +534,7 @@ class OchaAiChat {
       // embeddings. This is cheaper than calling the embedding API though we
       // lose in accuracy.
       if (!empty($content['pages'])) {
+        $content['pages'] = array_values($content['pages']);
         $content['embedding'] = $this->getMeanEmbedding($content['pages']);
       }
 


### PR DESCRIPTION
If a page of a PDF is skipped because it doesn't have content then the `$contents['pages']` is considered an object due to the missing numeric key which causes issue when converted to JSON to be indexed in elasticsearch. This PR fixes that by rekeying the pages array.